### PR TITLE
Updates travis intergration to use main as the default branch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
 branches:
   only:
-  - master
-  - another-branch
+    - main
+    - another-branch


### PR DESCRIPTION
## Problem

The default branch has been moved from master to main.

## Solution

Moves travis integration from the master branch to the main branch.
